### PR TITLE
Adds a nginx+php-fpm based dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:7.4-fpm
+RUN docker-php-ext-install -j$(nproc) mysqli
+
+RUN apt-get update -y \
+    && apt-get install -y nginx
+
+RUN mkdir /var/www/html/LightCurveRepository
+ADD . /var/www/html/LightCurveRepository
+RUN cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini
+COPY nginx-site.conf /etc/nginx/sites-enabled/default
+COPY entrypoint.sh /etc/entrypoint.sh
+
+EXPOSE 80 443
+ENTRYPOINT ["/etc/entrypoint.sh"]
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+service nginx start
+php-fpm
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
-service nginx start
-php-fpm
-
+php-fpm &
+nginx -g 'daemon off;'

--- a/nginx-site.conf
+++ b/nginx-site.conf
@@ -1,0 +1,22 @@
+server {
+    root    /var/www/html;
+
+    include /etc/nginx/default.d/*.conf;
+
+    index app.php index.php index.html index.htm;
+
+    client_max_body_size 30m;
+
+    location / {
+        try_files $uri $uri/ /app.php$is_args$args;
+    }
+
+    location ~ [^/]\.php(/|$) {
+        fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+        # Mitigate https://httpoxy.org/ vulnerabilities
+        fastcgi_param HTTP_PROXY "";
+        fastcgi_pass 127.0.0.1:9000;
+        fastcgi_index app.php;
+        include fastcgi.conf;
+    }
+}

--- a/nginx-site.conf
+++ b/nginx-site.conf
@@ -3,12 +3,12 @@ server {
 
     include /etc/nginx/default.d/*.conf;
 
-    index app.php index.php index.html index.htm;
+    index index.php index.html index.htm;
 
     client_max_body_size 30m;
 
     location / {
-        try_files $uri $uri/ /app.php$is_args$args;
+        try_files $uri $uri/ /index.php$is_args$args;
     }
 
     location ~ [^/]\.php(/|$) {
@@ -16,7 +16,7 @@ server {
         # Mitigate https://httpoxy.org/ vulnerabilities
         fastcgi_param HTTP_PROXY "";
         fastcgi_pass 127.0.0.1:9000;
-        fastcgi_index app.php;
+        fastcgi_index index.html;
         include fastcgi.conf;
     }
 }


### PR DESCRIPTION
Adds a minimal dockerfile setup.

Serves off of port 80 (nginx default) and adds a entrypoint

You can run the app as such:
```
docker build -t lcrepo .
docker run -d -p 8888:80 lcrepo
```

the visit:
http://localhost:8888/LightCurveRepository

